### PR TITLE
Remove AuthenticationManager.isUserValid. Remove AccessTokenIntrospec…

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/AccessTokenIntrospectionProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/AccessTokenIntrospectionProvider.java
@@ -126,27 +126,11 @@ public class AccessTokenIntrospectionProvider implements TokenIntrospectionProvi
         }
 
         ClientSessionContext clientSessionCtx = DefaultClientSessionContext.fromClientSessionAndScopeParameter(clientSession, token.getScope(), session);
-        AccessToken smallToken = getAccessTokenFromStoredData(token, userSession);
+        AccessToken smallToken = getAccessTokenFromStoredData(token);
         return tokenManager.transformIntrospectionAccessToken(session, smallToken, userSession, clientSessionCtx);
     }
 
-    public AccessToken transformAccessToken(AccessToken token) {
-        if (token == null) {
-            return null;
-        }
-
-        EventBuilder eventBuilder = new EventBuilder(realm, session, session.getContext().getConnection())
-                .event(EventType.INTROSPECT_TOKEN)
-                .detail(Details.AUTH_METHOD, Details.VALIDATE_ACCESS_TOKEN);
-        UserSessionModel userSession = tokenManager.getValidUserSessionIfTokenIsValid(session, realm, token, eventBuilder);
-
-        if(userSession == null) {
-            return token;
-        }
-        return transformAccessToken(token, userSession);
-    }
-
-    private AccessToken getAccessTokenFromStoredData(AccessToken token, UserSessionModel userSession) {
+    private AccessToken getAccessTokenFromStoredData(AccessToken token) {
         // Copy just "basic" claims from the initial token. The same like filled in TokenManager.initToken. The rest should be possibly added by protocol mappers (only if configured for introspection response)
         AccessToken newToken = new AccessToken();
         newToken.id(token.getId());

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -332,13 +332,13 @@ public class TokenManager {
         }
     }
 
-    private boolean isUserValid(KeycloakSession session, RealmModel realm, AccessToken token, UserModel user) {
+    public static boolean isUserValid(KeycloakSession session, RealmModel realm, AccessToken token, UserModel user) {
         if (user == null) {
-            logger.debugf("User does not exist for token introspection");
+            logger.debugf("User does not exists");
             return false;
         }
         if (!user.isEnabled()) {
-            logger.debugf("User is disable for token introspection");
+            logger.debugf("User '%s' is disabled", user.getUsername());
             return false;
         }
         try {

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -1410,14 +1410,14 @@ public class AuthenticationManager {
             UserModel user = null;
             if (token.getSessionState() == null) {
                 user = TokenManager.lookupUserFromStatelessToken(session, realm, token);
-                if (!isUserValid(session, realm, user, token)) {
+                if (!TokenManager.isUserValid(session, realm, token, user)) {
                     return null;
                 }
             } else {
                 userSession = session.sessions().getUserSession(realm, token.getSessionState());
                 if (userSession != null) {
                     user = userSession.getUser();
-                    if (!isUserValid(session, realm, user, token)) {
+                    if (!TokenManager.isUserValid(session, realm, token, user)) {
                         return null;
                     }
                 }
@@ -1480,23 +1480,6 @@ public class AuthenticationManager {
             logger.debugf("Client session for client '%s' not present in user session '%s'", client.getClientId(), userSession.getId());
             return false;
         }
-        return true;
-    }
-
-    private static boolean isUserValid(KeycloakSession session, RealmModel realm, UserModel user, AccessToken token) {
-        if (user == null || !user.isEnabled()) {
-            logger.debug("Unknown user in identity token");
-            return false;
-        }
-
-        if (! isLightweightUser(user)) {
-            int userNotBefore = session.users().getNotBeforeOfUser(realm, user);
-            if (token.getIssuedAt() < userNotBefore) {
-                logger.debug("User notBefore newer than token");
-                return false;
-            }
-        }
-
         return true;
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
@@ -34,6 +34,7 @@ import org.keycloak.services.managers.AppAuthManager;
 import org.keycloak.services.managers.Auth;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.resource.AccountResourceProvider;
+import org.keycloak.services.util.UserSessionUtil;
 import org.keycloak.theme.Theme;
 
 import jakarta.ws.rs.HttpMethod;
@@ -120,11 +121,14 @@ public class AccountLoader {
         }
 
         AccessToken accessToken = authResult.getToken();
+
+        UserSessionUtil.checkTokenIssuedAt(client.getRealm(), accessToken, authResult.getSession(), event, authResult.getClient());
+
         if (accessToken.getAudience() == null || accessToken.getResourceAccess(client.getClientId()) == null) {
             // transform for introspection to get the required claims
             AccessTokenIntrospectionProvider provider = (AccessTokenIntrospectionProvider) session.getProvider(TokenIntrospectionProvider.class,
                     AccessTokenIntrospectionProviderFactory.ACCESS_TOKEN_TYPE);
-            accessToken = provider.transformAccessToken(accessToken);
+            accessToken = provider.transformAccessToken(accessToken, authResult.getSession());
         }
 
         if (!accessToken.hasAudience(client.getClientId())) {

--- a/services/src/main/java/org/keycloak/services/util/UserSessionUtil.java
+++ b/services/src/main/java/org/keycloak/services/util/UserSessionUtil.java
@@ -101,7 +101,7 @@ public class UserSessionUtil {
         return userSession;
     }
 
-    private static void checkTokenIssuedAt(RealmModel realm, AccessToken token, UserSessionModel userSession, EventBuilder event, ClientModel client) {
+    public static void checkTokenIssuedAt(RealmModel realm, AccessToken token, UserSessionModel userSession, EventBuilder event, ClientModel client) {
         OAuth2Error error = new OAuth2Error().json(false).realm(realm);
         if (token.isIssuedBeforeSessionStart(userSession.getStarted())) {
             logger.debug("Stale token for user session");


### PR DESCRIPTION
…tionProvider.transformAccessToken(accessToken)

- Removed `AuthenticationManager.isUserValid` as it seems to be almost the same as `TokenManager.isUserValid` . Besides that tokenManager version has more flexible handling of "user notBefore" for the lightweight identity brokering users

- Removed `AccessTokenIntrospectionProvider.transformAccessToken(AccessToken token)` as it is called only from `AccountLoader`, but validated userSessionModel is already available here. It seems to me that only thing, which was checked in the `TokenManager.getValidUserSessionIfTokenIsValid` and not checked in `new AppAuthManager.BearerTokenAuthenticator(session).authenticate()` was the `UserSessionUtil.checkTokenIssuedAt`, so added that to `AccountLoader` .

